### PR TITLE
Route metric information

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,5 +13,5 @@
 
 *.iml
 .idea/
-
+.vscode
 openshift-state-metrics

--- a/manifests/openshift-state-metrics-cluster-role.yaml
+++ b/manifests/openshift-state-metrics-cluster-role.yaml
@@ -15,5 +15,9 @@ rules:
   verbs: ["list", "watch"]
 - apiGroups: ["quota.openshift.io"]
   resources:
-  - clusterresourcequota
+  - clusterresourcequotas
+  verbs: ["list", "watch"]
+- apiGroups: ["route.openshift.io"]
+  resources:
+  - routes
   verbs: ["list", "watch"]

--- a/pkg/collectors/builder.go
+++ b/pkg/collectors/builder.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/golang/glog"
 	appsv1 "github.com/openshift/api/apps/v1"
+	routev1 "github.com/openshift/api/route/v1"
 	buildv1 "github.com/openshift/api/build/v1"
 	quotav1 "github.com/openshift/api/quota/v1"
 	"golang.org/x/net/context"
@@ -110,6 +111,23 @@ var availableCollectors = map[string]func(f *Builder) *collector.Collector{
 	"buildconfigs":          func(b *Builder) *collector.Collector { return b.buildBuildConfigCollector() },
 	"builds":                func(b *Builder) *collector.Collector { return b.buildBuildCollector() },
 	"clusterresourcequotas": func(b *Builder) *collector.Collector { return b.buildQuotaCollector() },
+	"routes": func(b *Builder) *collector.Collector { return b.buildRouteCollector() },
+}
+
+func (b *Builder) buildRouteCollector() *collector.Collector {
+	filteredMetricFamilies := metric.FilterMetricFamilies(b.whiteBlackList, routeMetricFamilies)
+	composedMetricGenFuncs := metric.ComposeMetricGenFuncs(filteredMetricFamilies)
+
+	familyHeaders := metric.ExtractMetricFamilyHeaders(filteredMetricFamilies)
+
+	store := metricsstore.NewMetricsStore(
+		familyHeaders,
+		composedMetricGenFuncs,
+	)
+	reflectorPerNamespace(b.ctx, &routev1.Route{}, store,
+		b.apiserver, b.kubeconfig, b.namespaces, createRouteListWatch)
+
+	return collector.NewCollector(store)
 }
 
 func (b *Builder) buildDeploymentCollector() *collector.Collector {

--- a/pkg/collectors/builder.go
+++ b/pkg/collectors/builder.go
@@ -13,9 +13,9 @@ import (
 
 	"github.com/golang/glog"
 	appsv1 "github.com/openshift/api/apps/v1"
-	routev1 "github.com/openshift/api/route/v1"
 	buildv1 "github.com/openshift/api/build/v1"
 	quotav1 "github.com/openshift/api/quota/v1"
+	routev1 "github.com/openshift/api/route/v1"
 	"golang.org/x/net/context"
 )
 
@@ -111,7 +111,7 @@ var availableCollectors = map[string]func(f *Builder) *collector.Collector{
 	"buildconfigs":          func(b *Builder) *collector.Collector { return b.buildBuildConfigCollector() },
 	"builds":                func(b *Builder) *collector.Collector { return b.buildBuildCollector() },
 	"clusterresourcequotas": func(b *Builder) *collector.Collector { return b.buildQuotaCollector() },
-	"routes": func(b *Builder) *collector.Collector { return b.buildRouteCollector() },
+	"routes":                func(b *Builder) *collector.Collector { return b.buildRouteCollector() },
 }
 
 func (b *Builder) buildRouteCollector() *collector.Collector {

--- a/pkg/collectors/route.go
+++ b/pkg/collectors/route.go
@@ -1,134 +1,133 @@
 package collectors
 
 import (
-  metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-  "k8s.io/apimachinery/pkg/runtime"
-  "k8s.io/apimachinery/pkg/watch"
-  "k8s.io/client-go/tools/cache"
-  "k8s.io/client-go/tools/clientcmd"
-  "k8s.io/kube-state-metrics/pkg/metric"
-  "k8s.io/kube-state-metrics/pkg/version"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/watch"
+	"k8s.io/client-go/tools/cache"
+	"k8s.io/client-go/tools/clientcmd"
+	"k8s.io/kube-state-metrics/pkg/metric"
+	"k8s.io/kube-state-metrics/pkg/version"
 
-  "github.com/golang/glog"
-
-  "github.com/openshift/api/route/v1"
-  routeclient "github.com/openshift/client-go/route/clientset/versioned"
+	"github.com/golang/glog"
+	"github.com/openshift/api/route/v1"
+	routeclient "github.com/openshift/client-go/route/clientset/versioned"
 )
 
 var (
-  descRouteLabelsName          = "openshift_route_labels"
-  descRouteLabelsHelp          = "Kubernetes labels converted to Prometheus labels."
-  descRouteLabelsDefaultLabels = []string{"namespace", "route_name"}
+	descRouteLabelsName          = "openshift_route_labels"
+	descRouteLabelsHelp          = "Kubernetes labels converted to Prometheus labels."
+	descRouteLabelsDefaultLabels = []string{"namespace", "route_name"}
 
-  routeMetricFamilies = []metric.FamilyGenerator{
-    metric.FamilyGenerator{
-      Name: "openshift_route_created",
-      Type: metric.MetricTypeGauge,
-      Help: "Unix creation timestamp",
-      GenerateFunc: wrapRouteFunc(func(d *v1.Route) metric.Family {
-        f := metric.Family{}
+	routeMetricFamilies = []metric.FamilyGenerator{
+		metric.FamilyGenerator{
+			Name: "openshift_route_created",
+			Type: metric.MetricTypeGauge,
+			Help: "Unix creation timestamp",
+			GenerateFunc: wrapRouteFunc(func(d *v1.Route) metric.Family {
+				f := metric.Family{}
 
-        if !d.CreationTimestamp.IsZero() {
-          f.Metrics = append(f.Metrics, &metric.Metric{
-            Value: float64(d.CreationTimestamp.Unix()),
-          })
-        }
+				if !d.CreationTimestamp.IsZero() {
+					f.Metrics = append(f.Metrics, &metric.Metric{
+						Value: float64(d.CreationTimestamp.Unix()),
+					})
+				}
 
-        return f
-      }),
-    },
-    metric.FamilyGenerator{
-      Name: "openshift_route_info",
-      Type: metric.MetricTypeGauge,
-      Help: "Information about route.",
-      GenerateFunc: wrapRouteFunc(func(d *v1.Route) metric.Family {
-        f := metric.Family{}
-        var termination string
-        for _, m := range d.Status.Ingress {
-            if d.Spec.TLS != nil {
-              termination = string(d.Spec.TLS.Termination)
-            } else {
-              termination = ""
-            }
-          for _, n := range m.Conditions {
-            f.Metrics = append(f.Metrics, &metric.Metric{
-              LabelKeys: []string{"host_name", "tls_termination", "to_kind", "to_name", "router_name", "conditaion_type", "status"},
-              LabelValues: []string{
-                d.Spec.Host, 
-                termination, 
-                d.Spec.To.Kind, 
-                d.Spec.To.Name, 
-                m.RouterName, 
-                string(n.Type), 
-                string(n.Status),
-              },
-              Value: 1,
-            })
-          }
-        }
-        
-        return f
-      }),
-    },	
-    metric.FamilyGenerator{
-      Name: descRouteLabelsName,
-      Type: metric.MetricTypeGauge,
-      Help: descRouteLabelsHelp,
-      GenerateFunc: wrapRouteFunc(func(d *v1.Route) metric.Family {
-        labelKeys, labelValues := kubeLabelsToPrometheusLabels(d.Labels)
-        return metric.Family{Metrics: []*metric.Metric{
-          {
-            LabelKeys:   labelKeys,
-            LabelValues: labelValues,
-            Value:       1,
-          },
-        }}
-      }),
-    },
-  }
+				return f
+			}),
+		},
+		metric.FamilyGenerator{
+			Name: "openshift_route_info",
+			Type: metric.MetricTypeGauge,
+			Help: "Information about route.",
+			GenerateFunc: wrapRouteFunc(func(d *v1.Route) metric.Family {
+				f := metric.Family{}
+				var termination string
+				for _, m := range d.Status.Ingress {
+					if d.Spec.TLS != nil {
+						termination = string(d.Spec.TLS.Termination)
+					} else {
+						termination = ""
+					}
+					for _, n := range m.Conditions {
+						f.Metrics = append(f.Metrics, &metric.Metric{
+							LabelKeys: []string{"host_name", "tls_termination", "to_kind", "to_name", "router_name", "conditaion_type", "status"},
+							LabelValues: []string{
+								d.Spec.Host,
+								termination,
+								d.Spec.To.Kind,
+								d.Spec.To.Name,
+								m.RouterName,
+								string(n.Type),
+								string(n.Status),
+							},
+							Value: 1,
+						})
+					}
+				}
+
+				return f
+			}),
+		},
+		metric.FamilyGenerator{
+			Name: descRouteLabelsName,
+			Type: metric.MetricTypeGauge,
+			Help: descRouteLabelsHelp,
+			GenerateFunc: wrapRouteFunc(func(d *v1.Route) metric.Family {
+				labelKeys, labelValues := kubeLabelsToPrometheusLabels(d.Labels)
+				return metric.Family{Metrics: []*metric.Metric{
+					{
+						LabelKeys:   labelKeys,
+						LabelValues: labelValues,
+						Value:       1,
+					},
+				}}
+			}),
+		},
+	}
 )
 
 func wrapRouteFunc(f func(*v1.Route) metric.Family) func(interface{}) metric.Family {
-  return func(obj interface{}) metric.Family {
-    Route := obj.(*v1.Route)
+	return func(obj interface{}) metric.Family {
+		Route := obj.(*v1.Route)
 
-    metricFamily := f(Route)
+		metricFamily := f(Route)
 
-    for _, m := range metricFamily.Metrics {
-      m.LabelKeys = append(descRouteLabelsDefaultLabels, m.LabelKeys...)
-      m.LabelValues = append([]string{Route.Namespace, Route.Name}, m.LabelValues...)
-    }
+		for _, m := range metricFamily.Metrics {
+			m.LabelKeys = append(descRouteLabelsDefaultLabels, m.LabelKeys...)
+			m.LabelValues = append([]string{Route.Namespace, Route.Name}, m.LabelValues...)
+		}
 
-    return metricFamily
-  }
+		return metricFamily
+	}
 }
 
 func createRouteListWatch(apiserver string, kubeconfig string, ns string) cache.ListWatch {
-  routesclient, err := createRouteClient(apiserver, kubeconfig)
-  if err != nil {
-    glog.Fatalf("cannot create Route client: %v", err)
-  }
-  return cache.ListWatch{
-    ListFunc: func(opts metav1.ListOptions) (runtime.Object, error) {
-      return routesclient.RouteV1().Routes(ns).List(opts)
-    },
-    WatchFunc: func(opts metav1.ListOptions) (watch.Interface, error) {
-      return routesclient.RouteV1().Routes(ns).Watch(opts)
-    },
-  }
+	routesclient, err := createRouteClient(apiserver, kubeconfig)
+	if err != nil {
+		glog.Fatalf("cannot create Route client: %v", err)
+	}
+	return cache.ListWatch{
+		ListFunc: func(opts metav1.ListOptions) (runtime.Object, error) {
+			return routesclient.RouteV1().Routes(ns).List(opts)
+		},
+		WatchFunc: func(opts metav1.ListOptions) (watch.Interface, error) {
+			return routesclient.RouteV1().Routes(ns).Watch(opts)
+		},
+	}
 }
 
 func createRouteClient(apiserver string, kubeconfig string) (*routeclient.Clientset, error) {
-  config, err := clientcmd.BuildConfigFromFlags(apiserver, kubeconfig)
-  if err != nil {
-    return nil, err
-  }
+	config, err := clientcmd.BuildConfigFromFlags(apiserver, kubeconfig)
+	if err != nil {
+		return nil, err
+	}
 
-  config.UserAgent = version.GetVersion().String()
-  config.AcceptContentTypes = "application/vnd.kubernetes.protobuf,application/json"
-  config.ContentType = "application/vnd.kubernetes.protobuf"
+	config.UserAgent = version.GetVersion().String()
+	config.AcceptContentTypes = "application/vnd.kubernetes.protobuf,application/json"
+	config.ContentType = "application/vnd.kubernetes.protobuf"
 
-  client, err := routeclient.NewForConfig(config)
-  return client, err
+	client, err := routeclient.NewForConfig(config)
+	return client, err
 
 }

--- a/pkg/collectors/route.go
+++ b/pkg/collectors/route.go
@@ -1,0 +1,134 @@
+package collectors
+
+import (
+  metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+  "k8s.io/apimachinery/pkg/runtime"
+  "k8s.io/apimachinery/pkg/watch"
+  "k8s.io/client-go/tools/cache"
+  "k8s.io/client-go/tools/clientcmd"
+  "k8s.io/kube-state-metrics/pkg/metric"
+  "k8s.io/kube-state-metrics/pkg/version"
+
+  "github.com/golang/glog"
+
+  "github.com/openshift/api/route/v1"
+  routeclient "github.com/openshift/client-go/route/clientset/versioned"
+)
+
+var (
+  descRouteLabelsName          = "openshift_route_labels"
+  descRouteLabelsHelp          = "Kubernetes labels converted to Prometheus labels."
+  descRouteLabelsDefaultLabels = []string{"namespace", "route_name"}
+
+  routeMetricFamilies = []metric.FamilyGenerator{
+    metric.FamilyGenerator{
+      Name: "openshift_route_created",
+      Type: metric.MetricTypeGauge,
+      Help: "Unix creation timestamp",
+      GenerateFunc: wrapRouteFunc(func(d *v1.Route) metric.Family {
+        f := metric.Family{}
+
+        if !d.CreationTimestamp.IsZero() {
+          f.Metrics = append(f.Metrics, &metric.Metric{
+            Value: float64(d.CreationTimestamp.Unix()),
+          })
+        }
+
+        return f
+      }),
+    },
+    metric.FamilyGenerator{
+      Name: "openshift_route_info",
+      Type: metric.MetricTypeGauge,
+      Help: "Information about route.",
+      GenerateFunc: wrapRouteFunc(func(d *v1.Route) metric.Family {
+        f := metric.Family{}
+        var termination string
+        for _, m := range d.Status.Ingress {
+            if d.Spec.TLS != nil {
+              termination = string(d.Spec.TLS.Termination)
+            } else {
+              termination = ""
+            }
+          for _, n := range m.Conditions {
+            f.Metrics = append(f.Metrics, &metric.Metric{
+              LabelKeys: []string{"host_name", "tls_termination", "to_kind", "to_name", "router_name", "conditaion_type", "status"},
+              LabelValues: []string{
+                d.Spec.Host, 
+                termination, 
+                d.Spec.To.Kind, 
+                d.Spec.To.Name, 
+                m.RouterName, 
+                string(n.Type), 
+                string(n.Status),
+              },
+              Value: 1,
+            })
+          }
+        }
+        
+        return f
+      }),
+    },	
+    metric.FamilyGenerator{
+      Name: descRouteLabelsName,
+      Type: metric.MetricTypeGauge,
+      Help: descRouteLabelsHelp,
+      GenerateFunc: wrapRouteFunc(func(d *v1.Route) metric.Family {
+        labelKeys, labelValues := kubeLabelsToPrometheusLabels(d.Labels)
+        return metric.Family{Metrics: []*metric.Metric{
+          {
+            LabelKeys:   labelKeys,
+            LabelValues: labelValues,
+            Value:       1,
+          },
+        }}
+      }),
+    },
+  }
+)
+
+func wrapRouteFunc(f func(*v1.Route) metric.Family) func(interface{}) metric.Family {
+  return func(obj interface{}) metric.Family {
+    Route := obj.(*v1.Route)
+
+    metricFamily := f(Route)
+
+    for _, m := range metricFamily.Metrics {
+      m.LabelKeys = append(descRouteLabelsDefaultLabels, m.LabelKeys...)
+      m.LabelValues = append([]string{Route.Namespace, Route.Name}, m.LabelValues...)
+    }
+
+    return metricFamily
+  }
+}
+
+func createRouteListWatch(apiserver string, kubeconfig string, ns string) cache.ListWatch {
+  routesclient, err := createRouteClient(apiserver, kubeconfig)
+  if err != nil {
+    glog.Fatalf("cannot create Route client: %v", err)
+  }
+  return cache.ListWatch{
+    ListFunc: func(opts metav1.ListOptions) (runtime.Object, error) {
+      return routesclient.RouteV1().Routes(ns).List(opts)
+    },
+    WatchFunc: func(opts metav1.ListOptions) (watch.Interface, error) {
+      return routesclient.RouteV1().Routes(ns).Watch(opts)
+    },
+  }
+}
+
+func createRouteClient(apiserver string, kubeconfig string) (*routeclient.Clientset, error) {
+  config, err := clientcmd.BuildConfigFromFlags(apiserver, kubeconfig)
+  if err != nil {
+    return nil, err
+  }
+
+  config.UserAgent = version.GetVersion().String()
+  config.AcceptContentTypes = "application/vnd.kubernetes.protobuf,application/json"
+  config.ContentType = "application/vnd.kubernetes.protobuf"
+
+  client, err := routeclient.NewForConfig(config)
+  return client, err
+
+}

--- a/pkg/collectors/route.go
+++ b/pkg/collectors/route.go
@@ -1,9 +1,8 @@
 package collectors
 
 import (
-	"github.com/golang/glog"
-	"github.com/openshift/api/route/v1"
-	routeclient "github.com/openshift/client-go/route/clientset/versioned"
+	"strconv"
+
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/watch"
@@ -11,7 +10,11 @@ import (
 	"k8s.io/client-go/tools/clientcmd"
 	"k8s.io/kube-state-metrics/pkg/metric"
 	"k8s.io/kube-state-metrics/pkg/version"
-	"strconv"
+
+	"github.com/golang/glog"
+
+	v1 "github.com/openshift/api/route/v1"
+	routeclient "github.com/openshift/client-go/route/clientset/versioned"
 )
 
 var (

--- a/pkg/collectors/route_test.go
+++ b/pkg/collectors/route_test.go
@@ -1,0 +1,63 @@
+package collectors
+
+import (
+	"testing"
+	"time"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/openshift/api/route/v1"
+	"k8s.io/kube-state-metrics/pkg/metric"
+)
+
+func TestBuildConfigCollector(t *testing.T) {
+	// Fixed metadata on type and help text. We prepend this to every expected
+	// output so we only have to modify a single place when doing adjustments.
+	const metadata = `
+		# HELP openshift_route_created Unix creation timestamp
+		# TYPE openshift_route_created gauge
+		# HELP openshift_route_labels Kubernetes labels converted to Prometheus labels.
+		# TYPE openshift_route_labels gauge
+		# HELP openshift_route_info Information about route.
+		# TYPE openshift_route_info gauge
+	`
+	cases := []generateMetricsTestCase{
+		{
+			Obj: &v1.Route{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:              "route1",
+					CreationTimestamp: metav1.Time{Time: time.Unix(1500000000, 0)},
+					Namespace:         "ns1",
+					Labels: map[string]string{
+						"app": "good1",
+					},
+				},
+				Status: v1.RouteSpecStatus{},
+				Spec:   v1.RouteSpec{
+					Host: "example.com",
+					Strategy: &v1.TLSConfig{
+						Termination: "edge",
+					},
+					To: &v1.RouteTargetReference{
+						Kind: "Service",
+						Name: "svc1",
+						Weight: 100,
+					}
+				},
+			},
+			Want: `
+        openshift_route_created{route="route1",namespace="ns1"} 1.5e+09
+        openshift_route_labels{route="route1",label_app="good1",namespace="ns1"} 1
+				openshift_route_info{route="route1",namespace="ns1", host="example.com", path="", tls_termination="edge", to_kind="Service", to_name="svc1", to_weight="100"} 1
+				`,
+			MetricNames: []string{"openshift_route_labels", "openshift_route_info"},
+		},
+	}
+
+	for i, c := range cases {
+		c.Func = metric.ComposeMetricGenFuncs(buildconfigMetricFamilies)
+		if err := c.run(); err != nil {
+			t.Errorf("unexpected collecting result in %vth run:\n%s", i, err)
+		}
+	}
+}

--- a/pkg/options/collector.go
+++ b/pkg/options/collector.go
@@ -12,6 +12,7 @@ func init() {
 	koptions.DefaultCollectors["buildconfigs"] = struct{}{}
 	koptions.DefaultCollectors["builds"] = struct{}{}
 	koptions.DefaultCollectors["clusterresourcequotas"] = struct{}{}
+	koptions.DefaultCollectors["routes"] = struct{}{}
 }
 
 var (
@@ -21,5 +22,6 @@ var (
 		"buildconfigs":          struct{}{},
 		"builds":                struct{}{},
 		"clusterresourcequotas": struct{}{},
+		"routes": struct{}{},
 	}
 )

--- a/pkg/options/collector.go
+++ b/pkg/options/collector.go
@@ -22,6 +22,6 @@ var (
 		"buildconfigs":          struct{}{},
 		"builds":                struct{}{},
 		"clusterresourcequotas": struct{}{},
-		"routes": struct{}{},
+		"routes":                struct{}{},
 	}
 )


### PR DESCRIPTION
* Fixed a typo
* Add route metric information 

```
openshift_route_info{route="route1",namespace="ns1",host="example.com",path="",tls_termination="edge",to_kind="Service",to_name="svc1",to_weight="100"} 1
openshift_route_status{route="route1",namespace="ns1",host="example.com",status="True",type="Admitted",router_name="router1"} 1
```