### PR TITLE
use ga kubelet os label

### DIFF
--- a/jsonnet/openshift-state-metrics.libsonnet
+++ b/jsonnet/openshift-state-metrics.libsonnet
@@ -182,7 +182,7 @@ local k = import 'ksonnet/ksonnet.beta.4/k.libsonnet';
       deployment.mixin.metadata.withNamespace($._config.namespace) +
       deployment.mixin.metadata.withLabels(podLabels) +
       deployment.mixin.spec.selector.withMatchLabels(podLabels) +
-      deployment.mixin.spec.template.spec.withNodeSelector({ 'beta.kubernetes.io/os': 'linux' }) +
+      deployment.mixin.spec.template.spec.withNodeSelector({ 'kubernetes.io/os': 'linux' }) +
       deployment.mixin.spec.template.spec.withVolumes([privateVolume]) +
       deployment.mixin.spec.template.spec.withServiceAccountName('openshift-state-metrics') +
       deployment.mixin.spec.template.spec.withPriorityClassName('system-cluster-critical'),

--- a/manifests/openshift-state-metrics-deployment.yaml
+++ b/manifests/openshift-state-metrics-deployment.yaml
@@ -77,7 +77,7 @@ spec:
             cpu: 100m
             memory: 150Mi
       nodeSelector:
-        beta.kubernetes.io/os: linux
+        kubernetes.io/os: linux
       priorityClassName: system-cluster-critical
       serviceAccountName: openshift-state-metrics
       volumes:


### PR DESCRIPTION
change to use the GA kubelet OS label

ref: https://github.com/openshift/cluster-monitoring-operator/issues/371
ref: https://jira.coreos.com/browse/NODE-114