### PR TITLE
Fix/Extension for ClusterResourceQuotas

### DIFF
--- a/docs/clusterresourcequota-metrics.md
+++ b/docs/clusterresourcequota-metrics.md
@@ -4,6 +4,6 @@
 | ---------- | ----------- | ----------- | ----------- |
 | openshift_clusterresourcequota_created | Gauge | `name`=&lt;quota-name&gt; | STABLE |
 | openshift_clusterresourcequota_labels | Gauge | `name`=&lt;quota-name&gt; | STABLE |
-| openshift_clusterresourcequota_selector | Gauge | `name`=&lt;quota-name&gt; <br> `type=`=&lt;annotation\|label&gt; <br> `operator=`=&lt;Operator of MatchExpression, 'In' used for MatchLabels&gt;<br> `key`=&lt;key of annotation or label&gt; <br> `value`=&lt;value&gt; <br>  | STABLE |
+| openshift_clusterresourcequota_selector | Gauge | `name`=&lt;quota-name&gt; <br> `type=`=&lt;annotation\|match-labels\|match-expressions&gt; <br> `operator=`=&lt;Operator only for match-expressions&gt;<br> `key`=&lt;key of annotation or label&gt; <br> `value`=&lt;single value for match-labels and annotations&gt; <br> `values`=&lt;multiple values separated by ',' for match-expressions&gt; <br>  | STABLE |
 | openshift_clusterresourcequota_usage | Gauge | `name`=&lt;quota-name&gt; <br> `resource`=&lt;resource-name&gt; <br> `type`=&lt;hard\|used &gt;| STABLE |
 | openshift_clusterresourcequota_namespace_usage | Gauge | `name`=&lt;quota-name&gt; <br> `namespace`=&lt;namespace-name&gt; &gt; <br> `resource`=&lt;resource-name&gt; <br> `type`=&lt;hard\|used &gt;| STABLE |

--- a/pkg/collectors/cluster_resource_quota.go
+++ b/pkg/collectors/cluster_resource_quota.go
@@ -1,13 +1,14 @@
 package collectors
 
 import (
+	"strings"
+
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/watch"
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/client-go/tools/clientcmd"
 	"k8s.io/kube-state-metrics/pkg/metric"
-	"strings"
 
 	"github.com/golang/glog"
 	"github.com/openshift/api/quota/v1"
@@ -115,7 +116,7 @@ var (
 				f := metric.Family{}
 
 				sel := r.Spec.Selector
-				labelKeys := []string{"type", "key", "values"}
+				labelKeys := []string{"type", "key", "value"}
 				for key, value := range sel.AnnotationSelector {
 					f.Metrics = append(f.Metrics, &metric.Metric{
 						LabelKeys:   labelKeys,

--- a/pkg/collectors/cluster_resource_quota_test.go
+++ b/pkg/collectors/cluster_resource_quota_test.go
@@ -268,7 +268,7 @@ func TestClusterResourceQuotaCollector(t *testing.T) {
 			},
 			Want: `
        	openshift_clusterresourcequota_created{name="quota1"} 1.5e+09
-        openshift_clusterresourcequota_selector{name="quota1",type="annotation",key="clusterquota",values="test"} 1
+        openshift_clusterresourcequota_selector{name="quota1",type="annotation",key="clusterquota",value="test"} 1
 	    openshift_clusterresourcequota_usage{name="quota1",resource="memory",type="hard"} 2.1e+09
         openshift_clusterresourcequota_usage{name="quota1",resource="memory",type="used"} 5e+08		
 		openshift_clusterresourcequota_namespace_usage{name="quota1",namespace="myproject",resource="memory",type="hard"} 2.1e+09


### PR DESCRIPTION
fix for Hard Quota: when current no namespace is affected hard quota are empty. => hard quota must be taken from Spec instead of Status.

Added clusterresourcequota metrics:
- openshift_clusterresourcequota_selector Selector of cluster resource quota, which defines the affected namespaces
- openshift_clusterresourcequota_ns_usage Usage of applied resource quota per namespace