### PR TITLE
Conform build metrics to best practices

### DIFF
--- a/docs/build-metrics.md
+++ b/docs/build-metrics.md
@@ -2,10 +2,10 @@
 
 | Metric name| Metric type | Labels/tags | Status |
 | ---------- | ----------- | ----------- | ----------- |
-| openshift_build_created | Gauge | `build`=&lt;build-name&gt; <br> `namespace`=&lt;build-namespace&gt; | STABLE |
-| openshift_build_metadata_generation | Gauge | `build`=&lt;build-name&gt; <br> `namespace`=&lt;build-namespace&gt; | STABLE |
-| openshift_build_labels | Gauge | `build`=&lt;build-name&gt; <br> `namespace`=&lt;build-namespace&gt; | STABLE |
-| openshift_build_start | Gauge | `build`=&lt;build-name&gt; <br> `namespace`=&lt;build-namespace&gt; | STABLE |
-| openshift_build_complete | Gauge | `build`=&lt;build-name&gt; <br> `namespace`=&lt;build-namespace&gt; | STABLE |
-| openshift_build_duration | Gauge | `build`=&lt;build-name&gt; <br> `namespace`=&lt;build-namespace&gt; | STABLE |
-| openshift_build_status_phase | Gauge | `build`=&lt;build-name&gt; <br> `namespace`=&lt;build-namespace&gt; <br> `build_phase`=&lt;new\|pending\|running\|error\|failed\|complete\|canceled&gt; |STABLE |
+| openshift_build_created_timestamp_seconds | Gauge | `build`=&lt;build-name&gt; <br> `buildconfig`=&lt;build-config&gt; <br> `namespace`=&lt;build-namespace&gt; <br> `strategy`=&lt;custom\|docker\|jenkinspipeline\|source&gt; | STABLE |
+| openshift_build_metadata_generation_info | Gauge | `build`=&lt;build-name&gt; <br> `buildconfig`=&lt;build-config&gt; <br> `namespace`=&lt;build-namespace&gt; <br> `strategy`=&lt;custom\|docker\|jenkinspipeline\|source&gt; | STABLE |
+| openshift_build_labels | Gauge | `build`=&lt;build-name&gt; <br> `buildconfig`=&lt;build-config&gt; <br> `namespace`=&lt;build-namespace&gt; <br> `strategy`=&lt;custom\|docker\|jenkinspipeline\|source&gt; | STABLE |
+| openshift_build_start_timestamp_seconds | Gauge | `build`=&lt;build-name&gt; <br> `buildconfig`=&lt;build-config&gt; <br> `namespace`=&lt;build-namespace&gt; <br> `strategy`=&lt;custom\|docker\|jenkinspipeline\|source&gt; | STABLE |
+| openshift_build_completed_timestamp_seconds | Gauge | `build`=&lt;build-name&gt; <br> `buildconfig`=&lt;build-config&gt; <br> `namespace`=&lt;build-namespace&gt; <br> `strategy`=&lt;custom\|docker\|jenkinspipeline\|source&gt; | STABLE |
+| openshift_build_duration_seconds | Gauge | `build`=&lt;build-name&gt; <br> `buildconfig`=&lt;build-config&gt; <br> `namespace`=&lt;build-namespace&gt; <br> `strategy`=&lt;custom\|docker\|jenkinspipeline\|source&gt; | STABLE |
+| openshift_build_status_phase_total | Gauge | `build`=&lt;build-name&gt; <br> `build_phase`=&lt;new\|pending\|running\|error\|failed\|complete\|canceled&gt; <br> `buildconfig`=&lt;build-config&gt; <br> `namespace`=&lt;build-namespace&gt; <br> `strategy`=&lt;custom\|docker\|jenkinspipeline\|source&gt; |STABLE |


### PR DESCRIPTION
Update build state-metrics to conform with Prometheus best practices for names and units:

* Add `_timestamp_seconds` suffix to `openshift_build_created`
* Add `_info` suffix to `openshift_build_metadata_generation`
* Add `_total` suffix to `openshift_build_status_phase`
* Add `_timestamp_seconds` suffix to `openshift_build_start`
* Rename `openshift_build_complete` to `openshift_build_completed_timestamp_seconds`
* Add `_seconds` to `openshift_build_duration`. Update metric to compute seconds instead of nanos.

Also added the parent `buildconfig` name and the `strategy` for aggregation.
Doc has also been updated with new metric names and labels.