### PR TITLE
Bug 1858198: Fix TLS cipher suites

### DIFF
--- a/jsonnet/jsonnetfile.lock.json
+++ b/jsonnet/jsonnetfile.lock.json
@@ -1,14 +1,16 @@
 {
-    "dependencies": [
-        {
-            "name": "ksonnet",
-            "source": {
-                "git": {
-                    "remote": "https://github.com/ksonnet/ksonnet-lib",
-                    "subdir": ""
-                }
-            },
-            "version": "0d2f82676817bbf9e4acf6495b2090205f323b9f"
+  "dependencies": [
+    {
+      "source": {
+        "git": {
+          "remote": "https://github.com/ksonnet/ksonnet-lib",
+          "subdir": ""
         }
-    ]
+      },
+      "version": "0d2f82676817bbf9e4acf6495b2090205f323b9f",
+      "sum": "h28BXZ7+vczxYJ2sCt8JuR9+yznRtU/iA6DCpQUrtEg=",
+      "name": "ksonnet"
+    }
+  ],
+  "legacyImports": false
 }

--- a/jsonnet/openshift-state-metrics.libsonnet
+++ b/jsonnet/openshift-state-metrics.libsonnet
@@ -25,35 +25,34 @@ local k = import 'ksonnet/ksonnet.beta.4/k.libsonnet';
       kubeRbacProxy: 'quay.io/openshift/origin-kube-rbac-proxy',
     },
 
-    tlsCipherSuites: [
+    osmTLSCipherSuites: [
       'TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256',  // required by h2: http://golang.org/cl/30721
       'TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256',  // required by h2: http://golang.org/cl/30721
 
-      // 'TLS_RSA_WITH_RC4_128_SHA',            // insecure: https://access.redhat.com/security/cve/cve-2013-2566
-      // 'TLS_RSA_WITH_3DES_EDE_CBC_SHA',       // insecure: https://access.redhat.com/articles/2548661
-      // 'TLS_RSA_WITH_AES_128_CBC_SHA',        // disabled by h2
-      // 'TLS_RSA_WITH_AES_256_CBC_SHA',        // disabled by h2
-      'TLS_RSA_WITH_AES_128_CBC_SHA256',
-      // 'TLS_RSA_WITH_AES_128_GCM_SHA256',     // disabled by h2
-      // 'TLS_RSA_WITH_AES_256_GCM_SHA384',     // disabled by h2
-      // 'TLS_ECDHE_ECDSA_WITH_RC4_128_SHA',    // insecure: https://access.redhat.com/security/cve/cve-2013-2566
-      // 'TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA',// disabled by h2
-      // 'TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA',// disabled by h2
-      // 'TLS_ECDHE_RSA_WITH_RC4_128_SHA',      // insecure: https://access.redhat.com/security/cve/cve-2013-2566
-      // 'TLS_ECDHE_RSA_WITH_3DES_EDE_CBC_SHA', // insecure: https://access.redhat.com/articles/2548661
-      // 'TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA',  // disabled by h2
-      // 'TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA',  // disabled by h2
-      'TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA256',
-      'TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256',
+      // 'TLS_RSA_WITH_RC4_128_SHA',                // insecure: https://access.redhat.com/security/cve/cve-2013-2566
+      // 'TLS_RSA_WITH_3DES_EDE_CBC_SHA',           // insecure: https://access.redhat.com/articles/2548661
+      // 'TLS_RSA_WITH_AES_128_CBC_SHA',            // disabled by h2
+      // 'TLS_RSA_WITH_AES_256_CBC_SHA',            // disabled by h2
+      // 'TLS_RSA_WITH_AES_128_CBC_SHA256',         // insecure: https://access.redhat.com/security/cve/cve-2013-0169
+      // 'TLS_RSA_WITH_AES_128_GCM_SHA256',         // disabled by h2
+      // 'TLS_RSA_WITH_AES_256_GCM_SHA384',         // disabled by h2
+      // 'TLS_ECDHE_ECDSA_WITH_RC4_128_SHA',        // insecure: https://access.redhat.com/security/cve/cve-2013-2566
+      // 'TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA',    // disabled by h2
+      // 'TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA',    // disabled by h2
+      // 'TLS_ECDHE_RSA_WITH_RC4_128_SHA',          // insecure: https://access.redhat.com/security/cve/cve-2013-2566
+      // 'TLS_ECDHE_RSA_WITH_3DES_EDE_CBC_SHA',     // insecure: https://access.redhat.com/articles/2548661
+      // 'TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA',      // disabled by h2
+      // 'TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA',      // disabled by h2
+      // 'TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA256', // insecure: https://access.redhat.com/security/cve/cve-2013-0169
+      // 'TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256',   // insecure: https://access.redhat.com/security/cve/cve-2013-0169
 
       // disabled by h2 means: https://github.com/golang/net/blob/e514e69ffb8bc3c76a71ae40de0118d794855992/http2/ciphers.go
 
-      // 'TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384',   // TODO: Might not work with h2
-      // 'TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384', // TODO: Might not work with h2
-      // 'TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305',    // TODO: Might not work with h2
-      // 'TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305',  // TODO: Might not work with h2
+      'TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384',
+      'TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384',
+      'TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305',
+      'TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305',
     ],
-
   },
 
   openshiftStateMetrics+:: {
@@ -147,7 +146,7 @@ local k = import 'ksonnet/ksonnet.beta.4/k.libsonnet';
         container.withArgs([
           '--logtostderr',
           '--secure-listen-address=:8443',
-          '--tls-cipher-suites=' + std.join(',', $._config.tlsCipherSuites),
+          '--tls-cipher-suites=' + std.join(',', $._config.osmTLSCipherSuites),
           '--upstream=http://127.0.0.1:8081/',
           '--tls-cert-file=/etc/tls/private/tls.crt',
           '--tls-private-key-file=/etc/tls/private/tls.key',
@@ -162,7 +161,7 @@ local k = import 'ksonnet/ksonnet.beta.4/k.libsonnet';
         container.withArgs([
           '--logtostderr',
           '--secure-listen-address=:9443',
-          '--tls-cipher-suites=' + std.join(',', $._config.tlsCipherSuites),
+          '--tls-cipher-suites=' + std.join(',', $._config.osmTLSCipherSuites),
           '--upstream=http://127.0.0.1:8082/',
           '--tls-cert-file=/etc/tls/private/tls.crt',
           '--tls-private-key-file=/etc/tls/private/tls.key',

--- a/manifests/openshift-state-metrics-deployment.yaml
+++ b/manifests/openshift-state-metrics-deployment.yaml
@@ -19,7 +19,7 @@ spec:
       - args:
         - --logtostderr
         - --secure-listen-address=:8443
-        - --tls-cipher-suites=TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_RSA_WITH_AES_128_CBC_SHA256,TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA256,TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256
+        - --tls-cipher-suites=TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305
         - --upstream=http://127.0.0.1:8081/
         - --tls-cert-file=/etc/tls/private/tls.crt
         - --tls-private-key-file=/etc/tls/private/tls.key
@@ -33,7 +33,7 @@ spec:
             cpu: 20m
             memory: 40Mi
           requests:
-            cpu: 10m
+            cpu: 1m
             memory: 20Mi
         volumeMounts:
         - mountPath: /etc/tls/private
@@ -42,7 +42,7 @@ spec:
       - args:
         - --logtostderr
         - --secure-listen-address=:9443
-        - --tls-cipher-suites=TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_RSA_WITH_AES_128_CBC_SHA256,TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA256,TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256
+        - --tls-cipher-suites=TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305
         - --upstream=http://127.0.0.1:8082/
         - --tls-cert-file=/etc/tls/private/tls.crt
         - --tls-private-key-file=/etc/tls/private/tls.key
@@ -56,7 +56,7 @@ spec:
             cpu: 20m
             memory: 40Mi
           requests:
-            cpu: 10m
+            cpu: 1m
             memory: 20Mi
         volumeMounts:
         - mountPath: /etc/tls/private
@@ -71,10 +71,10 @@ spec:
         name: openshift-state-metrics
         resources:
           limits:
-            cpu: 100m
+            cpu: 1m
             memory: 150Mi
           requests:
-            cpu: 100m
+            cpu: 1m
             memory: 150Mi
       nodeSelector:
         kubernetes.io/os: linux


### PR DESCRIPTION
Use the same settings as in https://github.com/coreos/kube-prometheus/pull/616

change global variable name to prevent overriding it in CMO.