### PR TITLE
Adding the right build comment as per go 1.17

### DIFF
--- a/pkg/proc/reaper.go
+++ b/pkg/proc/reaper.go
@@ -1,3 +1,4 @@
+//go:build linux
 // +build linux
 
 package proc

--- a/pkg/proc/reaper_unsupported.go
+++ b/pkg/proc/reaper_unsupported.go
@@ -1,3 +1,4 @@
+//go:build !linux
 // +build !linux
 
 package proc


### PR DESCRIPTION
With Go 1.17 the build comment has changed resulting in go-fmt errors.

https://khanakia.medium.com/go-1-17-compiler-got-faster-and-go-mod-api-changed-71f35267d616

This change is required for this https://github.com/openshift/openshift-state-metrics/pull/81 to go through.