### PR TITLE
Updating openshift-state-metrics images to be consistent with ART

### DIFF
--- a/.ci-operator.yaml
+++ b/.ci-operator.yaml
@@ -1,4 +1,4 @@
 build_root_image:
   name: release
   namespace: openshift
-  tag: rhel-8-release-golang-1.17-openshift-4.11
+  tag: rhel-8-release-golang-1.18-openshift-4.11

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.ci.openshift.org/ocp/builder:rhel-8-golang-1.17-openshift-4.11 AS builder
+FROM registry.ci.openshift.org/ocp/builder:rhel-8-golang-1.18-openshift-4.11 AS builder
 WORKDIR /go/src/github.com/openshift/openshift-state-metrics
 COPY . .
 RUN make build


### PR DESCRIPTION
Reconciling with https://github.com/openshift/ocp-build-data/tree/5bdff8f034891d949f702da1c194719005a2df3a/images/openshift-state-metrics.yml