### PR TITLE
OCPBUGS-48747: Dedup `*_status` metrics for Routes

### DIFF
--- a/pkg/collectors/route.go
+++ b/pkg/collectors/route.go
@@ -68,6 +68,9 @@ var (
 				return f
 			}),
 		},
+		// OCPBUGS-48747: `type: Admitted` should be unique for each
+		// `status.ingress` entry, so there's no need for
+		// de-duplication here for that case.
 		metric.FamilyGenerator{
 			Name: "openshift_route_status",
 			Type: metric.MetricTypeGauge,


### PR DESCRIPTION
There were certain cases for which `v1.Conditions` generated duplicate
metrics, which led to `PrometheusDuplicateTimestamp` alerts (see [1]).

[1]: https://github.com/prometheus/prometheus/issues/14089#issuecomment-2107578174

This also nil-checks `<Route>.Spec.To.Weight` so we don't unnecessarily
need to include `*_info` metrics for test cases specific to this patch.
In a real-world scenario this field is always populated.

Signed-off-by: Pranshu Srivastava <rexagod@gmail.com>